### PR TITLE
Bump discordsrv from 1.26.0 to 1.26.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <dependency>
             <groupId>com.discordsrv</groupId>
             <artifactId>discordsrv</artifactId>
-            <version>1.26.0</version>
+            <version>1.26.1</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Bumps discordsrv from 1.26.0 to 1.26.1.

---
updated-dependencies:
- dependency-name: com.discordsrv:discordsrv dependency-type: direct:production update-type: version-update:semver-patch ...